### PR TITLE
docs: add README and clean up gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,17 @@ build/
 *.tsbuildinfo
 .turbo/
 coverage/
+
+# OS
+.DS_Store
+Thumbs.db
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# Generated project output (pnpm generate defaults to output/)
+/output/
+/test-app/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,142 @@
+# Netrock
+
+Project generator for production-grade .NET + SvelteKit web applications.
+
+Pick your features, name your project, get a complete repository - builds, tests pass, ready to deploy.
+
+## Quick start
+
+```bash
+git clone https://github.com/fpindej/netrock-cli.git
+cd netrock-cli
+pnpm install
+pnpm generate
+```
+
+The interactive generator asks for a project name, lets you pick a preset or choose features individually, and writes the project to `output/<project-name>/`.
+
+```
+cd output/your-project
+dotnet build src/backend/YourProject.slnx
+dotnet test src/backend/YourProject.slnx
+```
+
+## What you get
+
+A generated project includes:
+
+- **.NET 10 API** - Clean Architecture (Domain, Shared, Application, Infrastructure, WebApi)
+- **PostgreSQL** - EF Core with strongly-typed configuration
+- **Health checks** - Readiness and liveness endpoints
+- **OpenAPI** - Auto-generated API documentation
+- **Serilog** - Structured logging with OpenTelemetry support
+- **Security** - CORS, rate limiting, security headers, exception handling middleware
+- **Tests** - Architecture tests (NetArchTest) and unit tests (xUnit)
+- **Docker** - Dockerfile and build configuration
+
+## Features
+
+Features are modular. Pick what you need, skip what you don't. Dependencies are resolved automatically.
+
+| Feature | Description | Dependencies |
+|---|---|---|
+| **Core** | Clean Architecture skeleton, PostgreSQL, health checks | (always included) |
+| **Authentication** | Local login, registration, token refresh, user profile | Core |
+| **Email** | SMTP service with Fluid templates | Core |
+| **Email verification** | Confirmation token flow | Auth, Email |
+| **Password reset** | Forgot/reset password via email | Auth, Email |
+| **Two-factor auth** | TOTP-based 2FA with recovery codes | Auth |
+| **External OAuth** | Google, GitHub, Microsoft, and more | Auth |
+| **Captcha** | Cloudflare Turnstile on register and forgot password | Auth |
+| **Background jobs** | Hangfire job scheduling with PostgreSQL storage | Core |
+| **File storage** | S3/MinIO file storage abstraction | Core |
+| **Avatar uploads** | User avatar upload with image processing | Auth, File storage |
+| **Audit trail** | Event logging for security-sensitive actions | Core |
+| **Admin panel** | User management, role management, system admin | Auth |
+| **Aspire** | .NET Aspire for local dev orchestration with OTEL | Core |
+| **SvelteKit frontend** | Full reference frontend with all feature UIs | Auth |
+
+### Presets
+
+| Preset | What's included |
+|---|---|
+| **Minimal** | Core + Auth |
+| **Standard** | Core, Auth, Email, Email verification, Password reset, Jobs, Audit, Admin, Aspire, Frontend |
+| **Full** | Everything |
+| **API only** | Everything except the SvelteKit frontend |
+
+## Project structure
+
+```
+netrock-cli/
+  packages/
+    core/           Pure TypeScript engine (no framework dependencies)
+      src/
+        engine/     Generator, template processor, naming, secrets
+        features/   Feature definitions, dependency graph, manifests
+        graph/      Dependency resolver
+        presets/    Preset configurations
+      tests/        Unit + integration tests (vitest)
+  scripts/
+    generate.ts     Interactive CLI script
+  templates/        Source template files (valid .NET code with @feature markers)
+```
+
+## How it works
+
+1. **Feature resolution** - Your selection is expanded with required dependencies
+2. **File collection** - Each enabled feature's manifest declares which template files to include
+3. **Template processing** - Files with `@feature` markers have conditional blocks stripped or kept based on your selection
+4. **Namespace substitution** - `MyProject` placeholder is replaced with your project name in PascalCase (paths, content, DB context, solution file)
+5. **Secret generation** - JWT signing key and encryption key are generated fresh
+
+### Template markers
+
+Template files are valid, compilable C# code. Conditional sections use comment markers:
+
+```csharp
+// @feature auth
+using MyProject.Infrastructure.Features.Authentication;
+// @end
+
+// @feature !auth
+internal class MyProjectDbContext(DbContextOptions<MyProjectDbContext> options) : DbContext(options)
+// @end
+// @feature auth
+internal class MyProjectDbContext(DbContextOptions<MyProjectDbContext> options)
+    : IdentityDbContext<ApplicationUser, ApplicationRole, Guid>(options)
+// @end
+```
+
+`@feature name` keeps the block when the feature is enabled. `@feature !name` keeps it when the feature is disabled. Both markers are stripped from output.
+
+## Development
+
+```bash
+pnpm install
+pnpm test          # Run all tests
+pnpm build         # Build all packages
+pnpm generate      # Try the generator
+```
+
+### Tests
+
+```bash
+cd packages/core
+pnpm test              # All 56 tests
+pnpm test:watch        # Watch mode
+```
+
+Integration tests generate a full project, run `dotnet build` and `dotnet test` on it, and verify the output compiles and passes.
+
+## Progress
+
+- [x] Phase 1 - Feature mapping (14 features defined with dependency graph)
+- [x] Phase 2 - Core engine (template processor, namespace substitution, scaffolding)
+- [x] Core manifest - Generates a buildable, testable .NET project
+- [ ] Phase 3 - Feature manifests (auth, email, jobs, audit, admin, aspire, frontend, ...)
+- [ ] Web UI - Interactive generator at netrock.dev
+
+## License
+
+MIT

--- a/scripts/generate.ts
+++ b/scripts/generate.ts
@@ -80,7 +80,7 @@ async function main(): Promise<void> {
 	}
 
 	// 3. Output directory
-	const defaultDir = resolve(projectName);
+	const defaultDir = resolve('output', projectName);
 	const outputDir = await input({
 		message: 'Output directory',
 		default: defaultDir


### PR DESCRIPTION
## Summary

- Add README with project overview, feature table, presets, architecture docs, and development guide
- Update .gitignore for OS files (.DS_Store), IDE dirs (.idea, .vscode), and generated output
- Default generate script output to `output/<project-name>/` instead of repo root