### PR TITLE
feat: add all 14 feature manifests (Phase 3)

### DIFF
--- a/packages/core/src/manifests/admin.ts
+++ b/packages/core/src/manifests/admin.ts
@@ -1,0 +1,196 @@
+import { registerManifest } from '../features/manifest.js';
+
+/** Registers the admin feature manifest - admin panel with user management, roles, and permissions. */
+export function registerAdminManifest(): void {
+	registerManifest({
+		featureId: 'admin',
+		files: [
+			// Application - DTOs
+			{
+				path: 'src/backend/MyProject.Application/Features/Admin/Dtos/AdminRoleOutput.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Application/Features/Admin/Dtos/AdminUserListOutput.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Application/Features/Admin/Dtos/AdminUserOutput.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Application/Features/Admin/Dtos/AssignRoleInput.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Application/Features/Admin/Dtos/CreateRoleInput.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Application/Features/Admin/Dtos/CreateUserInput.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Application/Features/Admin/Dtos/PermissionGroupOutput.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Application/Features/Admin/Dtos/RoleDetailOutput.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Application/Features/Admin/Dtos/SetRolePermissionsInput.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Application/Features/Admin/Dtos/UpdateRoleInput.cs',
+				templated: false
+			},
+
+			// Application - Interfaces
+			{ path: 'src/backend/MyProject.Application/Features/Admin/IAdminService.cs', templated: false },
+			{
+				path: 'src/backend/MyProject.Application/Features/Admin/IRoleManagementService.cs',
+				templated: false
+			},
+
+			// Infrastructure
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Admin/Extensions/ServiceCollectionExtensions.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Admin/Services/AdminService.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Admin/Services/RoleManagementService.cs',
+				templated: false
+			},
+
+			// WebApi - Controller and mappers
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Admin/AdminController.cs',
+				templated: false
+			},
+			{ path: 'src/backend/MyProject.WebApi/Features/Admin/AdminMapper.cs', templated: false },
+			{ path: 'src/backend/MyProject.WebApi/Features/Admin/PiiMasker.cs', templated: false },
+
+			// WebApi - Admin DTOs
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Admin/Dtos/AdminRoleResponse.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Admin/Dtos/AdminUserResponse.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Admin/Dtos/AssignRole/AssignRoleRequest.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Admin/Dtos/AssignRole/AssignRoleRequestValidator.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Admin/Dtos/CreateRole/CreateRoleRequest.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Admin/Dtos/CreateRole/CreateRoleRequestValidator.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Admin/Dtos/CreateUser/CreateUserRequest.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Admin/Dtos/CreateUser/CreateUserRequestValidator.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Admin/Dtos/DisableTwoFactor/DisableTwoFactorRequest.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Admin/Dtos/DisableTwoFactor/DisableTwoFactorRequestValidator.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Admin/Dtos/ListUsers/ListUsersRequest.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Admin/Dtos/ListUsers/ListUsersRequestValidator.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Admin/Dtos/ListUsers/ListUsersResponse.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Admin/Dtos/PermissionGroupResponse.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Admin/Dtos/RoleDetailResponse.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Admin/Dtos/SetPermissions/SetPermissionsRequest.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Admin/Dtos/SetPermissions/SetPermissionsRequestValidator.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Admin/Dtos/UpdateRole/UpdateRoleRequest.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Admin/Dtos/UpdateRole/UpdateRoleRequestValidator.cs',
+				templated: false
+			},
+
+			// Tests
+			{
+				path: 'src/backend/tests/MyProject.Api.Tests/Features/Admin/AdminMapperPiiTests.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/tests/MyProject.Api.Tests/Features/Admin/PiiMaskerTests.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/tests/MyProject.Api.Tests/Controllers/AdminControllerTests.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/tests/MyProject.Api.Tests/Controllers/AdminControllerDisableTwoFactorTests.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/tests/MyProject.Api.Tests/Validators/AdminValidatorTests.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/tests/MyProject.Api.Tests/Validators/DisableTwoFactorRequestValidatorTests.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/tests/MyProject.Component.Tests/Services/AdminServiceTests.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/tests/MyProject.Component.Tests/Services/AdminServiceDisableTwoFactorTests.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/tests/MyProject.Component.Tests/Services/RoleManagementServiceTests.cs',
+				templated: false
+			}
+		]
+	});
+}

--- a/packages/core/src/manifests/aspire.ts
+++ b/packages/core/src/manifests/aspire.ts
@@ -1,0 +1,22 @@
+import { registerManifest } from '../features/manifest.js';
+
+/** Registers the aspire feature manifest - .NET Aspire orchestration with AppHost and HealthProbe. */
+export function registerAspireManifest(): void {
+	registerManifest({
+		featureId: 'aspire',
+		files: [
+			// AppHost
+			{ path: 'src/backend/MyProject.AppHost/MyProject.AppHost.csproj', templated: false },
+			{ path: 'src/backend/MyProject.AppHost/Program.cs', templated: false },
+			{
+				path: 'src/backend/MyProject.AppHost/Properties/launchSettings.json',
+				templated: false
+			},
+			{ path: 'src/backend/MyProject.AppHost/appsettings.json', templated: false },
+
+			// HealthProbe
+			{ path: 'src/backend/HealthProbe/HealthProbe.csproj', templated: false },
+			{ path: 'src/backend/HealthProbe/Program.cs', templated: false }
+		]
+	});
+}

--- a/packages/core/src/manifests/audit.ts
+++ b/packages/core/src/manifests/audit.ts
@@ -1,0 +1,60 @@
+import { registerManifest } from '../features/manifest.js';
+
+/** Registers the audit feature manifest - audit trail with event logging and querying. */
+export function registerAuditManifest(): void {
+	registerManifest({
+		featureId: 'audit',
+		files: [
+			// Application
+			{ path: 'src/backend/MyProject.Application/Features/Audit/AuditActions.cs', templated: false },
+			{
+				path: 'src/backend/MyProject.Application/Features/Audit/Dtos/AuditEventListOutput.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Application/Features/Audit/Dtos/AuditEventOutput.cs',
+				templated: false
+			},
+			{ path: 'src/backend/MyProject.Application/Features/Audit/IAuditService.cs', templated: false },
+
+			// Infrastructure
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Audit/Configurations/AuditEventConfiguration.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Audit/Extensions/ServiceCollectionExtensions.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Audit/Models/AuditEvent.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Audit/Services/AuditService.cs',
+				templated: false
+			},
+
+			// WebApi
+			{ path: 'src/backend/MyProject.WebApi/Features/Audit/AuditMapper.cs', templated: false },
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Audit/Dtos/AuditEventResponse.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Audit/Dtos/ListAuditEvents/ListAuditEventsRequest.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Audit/Dtos/ListAuditEvents/ListAuditEventsResponse.cs',
+				templated: false
+			},
+
+			// Tests
+			{
+				path: 'src/backend/tests/MyProject.Component.Tests/Services/AuditServiceTests.cs',
+				templated: false
+			}
+		]
+	});
+}

--- a/packages/core/src/manifests/auth.ts
+++ b/packages/core/src/manifests/auth.ts
@@ -1,0 +1,373 @@
+import { registerManifest } from '../features/manifest.js';
+
+/** Registers the auth feature manifest - core authentication, authorization, user profile, and identity. */
+export function registerAuthManifest(): void {
+	registerManifest({
+		featureId: 'auth',
+		files: [
+			// Application - Identity
+			{ path: 'src/backend/MyProject.Application/Identity/Constants/AppPermissions.cs', templated: false },
+			{ path: 'src/backend/MyProject.Application/Identity/Constants/AppRoles.cs', templated: false },
+			{
+				path: 'src/backend/MyProject.Application/Identity/Constants/PermissionDefinition.cs',
+				templated: false
+			},
+			{ path: 'src/backend/MyProject.Application/Identity/Dtos/DeleteAccountInput.cs', templated: false },
+			{ path: 'src/backend/MyProject.Application/Identity/IUserContext.cs', templated: false },
+			{ path: 'src/backend/MyProject.Application/Identity/IUserService.cs', templated: false },
+
+			// Application - Caching
+			{ path: 'src/backend/MyProject.Application/Caching/Constants/CacheKeys.cs', templated: false },
+
+			// Application - Cookies
+			{ path: 'src/backend/MyProject.Application/Cookies/Constants/CookieNames.cs', templated: false },
+			{ path: 'src/backend/MyProject.Application/Cookies/ICookieService.cs', templated: false },
+
+			// Application - Cryptography
+			{ path: 'src/backend/MyProject.Application/Cryptography/ISecretEncryptionService.cs', templated: false },
+
+			// Application - Authentication DTOs and interfaces
+			{
+				path: 'src/backend/MyProject.Application/Features/Authentication/IAuthenticationService.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Application/Features/Authentication/Dtos/AuthenticationOutput.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Application/Features/Authentication/Dtos/ChangePasswordInput.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Application/Features/Authentication/Dtos/LoginOutput.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Application/Features/Authentication/Dtos/RegisterInput.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Application/Features/Authentication/Dtos/UpdateProfileInput.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Application/Features/Authentication/Dtos/UserOutput.cs',
+				templated: false
+			},
+
+			// Infrastructure - Caching
+			{
+				path: 'src/backend/MyProject.Infrastructure/Caching/Extensions/ServiceCollectionExtensions.cs',
+				templated: false
+			},
+			{ path: 'src/backend/MyProject.Infrastructure/Caching/Options/CachingOptions.cs', templated: false },
+			{
+				path: 'src/backend/MyProject.Infrastructure/Caching/Services/NoOpHybridCache.cs',
+				templated: false
+			},
+
+			// Infrastructure - Cookies
+			{ path: 'src/backend/MyProject.Infrastructure/Cookies/CookieService.cs', templated: false },
+			{
+				path: 'src/backend/MyProject.Infrastructure/Cookies/Extensions/ServiceCollectionExtensions.cs',
+				templated: false
+			},
+
+			// Infrastructure - Cryptography
+			{
+				path: 'src/backend/MyProject.Infrastructure/Cryptography/AesGcmEncryptionService.cs',
+				templated: false
+			},
+			{ path: 'src/backend/MyProject.Infrastructure/Cryptography/HashHelper.cs', templated: false },
+
+			// Infrastructure - Authentication
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Authentication/Configurations/RefreshTokenConfiguration.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Authentication/Extensions/ServiceCollectionExtensions.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Authentication/Models/ApplicationRole.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Authentication/Models/ApplicationUser.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Authentication/Models/RefreshToken.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Authentication/Options/AuthenticationOptions.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Authentication/Services/AuthenticationService.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Authentication/Services/ITokenProvider.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Authentication/Services/JwtTokenProvider.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Authentication/Services/TokenSessionService.cs',
+				templated: false
+			},
+
+			// Infrastructure - Identity
+			{
+				path: 'src/backend/MyProject.Infrastructure/Identity/Extensions/ServiceCollectionExtensions.cs',
+				templated: false
+			},
+			{ path: 'src/backend/MyProject.Infrastructure/Identity/Services/UserService.cs', templated: false },
+			{ path: 'src/backend/MyProject.Infrastructure/Identity/UserContext.cs', templated: false },
+
+			// Infrastructure - Persistence interceptors and seed
+			{
+				path: 'src/backend/MyProject.Infrastructure/Persistence/Interceptors/AuditingInterceptor.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Infrastructure/Persistence/Interceptors/UserCacheInvalidationInterceptor.cs',
+				templated: false
+			},
+			{ path: 'src/backend/MyProject.Infrastructure/Persistence/Options/SeedOptions.cs', templated: false },
+
+			// WebApi - Authorization
+			{
+				path: 'src/backend/MyProject.WebApi/Authorization/PermissionAuthorizationHandler.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Authorization/PermissionPolicyProvider.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Authorization/PermissionRequirement.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Authorization/ProblemDetailsAuthorizationHandler.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Authorization/RequirePermissionAttribute.cs',
+				templated: false
+			},
+
+			// WebApi - Auth controller and mapper
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Authentication/AuthController.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Authentication/AuthMapper.cs',
+				templated: false
+			},
+
+			// WebApi - Auth DTOs: Login
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Authentication/Dtos/Login/AuthenticationResponse.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Authentication/Dtos/Login/LoginRequest.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Authentication/Dtos/Login/LoginRequestValidator.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Authentication/Dtos/Login/RefreshRequest.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Authentication/Dtos/Login/RefreshRequestValidator.cs',
+				templated: false
+			},
+
+			// WebApi - Auth DTOs: Register
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Authentication/Dtos/Register/RegisterRequest.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Authentication/Dtos/Register/RegisterRequestValidator.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Authentication/Dtos/Register/RegisterResponse.cs',
+				templated: false
+			},
+
+			// WebApi - Auth DTOs: ChangePassword
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Authentication/Dtos/ChangePassword/ChangePasswordRequest.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Authentication/Dtos/ChangePassword/ChangePasswordRequestValidator.cs',
+				templated: false
+			},
+
+			// WebApi - Users
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Users/Dtos/DeleteAccount/DeleteAccountRequest.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Users/Dtos/DeleteAccount/DeleteAccountRequestValidator.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Users/Dtos/UpdateUserRequest.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Users/Dtos/UpdateUserRequestValidator.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Users/Dtos/UserResponse.cs',
+				templated: false
+			},
+			{ path: 'src/backend/MyProject.WebApi/Features/Users/UserMapper.cs', templated: false },
+			{ path: 'src/backend/MyProject.WebApi/Features/Users/UsersController.cs', templated: false },
+
+			// WebApi - Routing
+			{ path: 'src/backend/MyProject.WebApi/Routing/RoleNameRouteConstraint.cs', templated: false },
+
+			// Documentation
+			{ path: 'src/backend/AGENTS.md', templated: false },
+
+			// Tests - Api
+			{
+				path: 'src/backend/tests/MyProject.Api.Tests/MyProject.Api.Tests.csproj',
+				templated: false
+			},
+			{ path: 'src/backend/tests/MyProject.Api.Tests/GlobalUsings.cs', templated: false },
+			{
+				path: 'src/backend/tests/MyProject.Api.Tests/Fixtures/CustomWebApplicationFactory.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/tests/MyProject.Api.Tests/Fixtures/TestAuthHandler.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/tests/MyProject.Api.Tests/Contracts/ResponseContracts.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/tests/MyProject.Api.Tests/Middlewares/OriginValidationMiddlewareTests.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/tests/MyProject.Api.Tests/Validation/CorsOptionsValidationTests.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/tests/MyProject.Api.Tests/Validation/RateLimitingOptionsValidationTests.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/tests/MyProject.Api.Tests/Controllers/AuthControllerTests.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/tests/MyProject.Api.Tests/Controllers/UsersControllerTests.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/tests/MyProject.Api.Tests/Validators/LoginRequestValidatorTests.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/tests/MyProject.Api.Tests/Validators/RegisterRequestValidatorTests.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/tests/MyProject.Api.Tests/Validators/UserValidatorTests.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/tests/MyProject.Api.Tests/Validators/ChangePasswordRequestValidatorTests.cs',
+				templated: false
+			},
+
+			// Tests - Component
+			{
+				path: 'src/backend/tests/MyProject.Component.Tests/MyProject.Component.Tests.csproj',
+				templated: false
+			},
+			{
+				path: 'src/backend/tests/MyProject.Component.Tests/GlobalUsings.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/tests/MyProject.Component.Tests/Fixtures/IdentityMockHelpers.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/tests/MyProject.Component.Tests/Fixtures/MockHttpClientFactory.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/tests/MyProject.Component.Tests/Fixtures/MockHttpMessageHandler.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/tests/MyProject.Component.Tests/Fixtures/TestDbContextFactory.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/tests/MyProject.Component.Tests/Persistence/BaseEntityRepositoryTests.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/tests/MyProject.Component.Tests/Services/AuthenticationServiceTests.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/tests/MyProject.Component.Tests/Services/UserServiceTests.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/tests/MyProject.Component.Tests/Services/NoOpHybridCacheTests.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/tests/MyProject.Component.Tests/Cryptography/AesGcmEncryptionServiceTests.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/tests/MyProject.Component.Tests/Validation/AuthenticationOptionsValidationTests.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/tests/MyProject.Component.Tests/Validation/CachingOptionsValidationTests.cs',
+				templated: false
+			},
+
+			// Tests - Unit
+			{
+				path: 'src/backend/tests/MyProject.Unit.Tests/Application/AppPermissionsTests.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/tests/MyProject.Unit.Tests/Application/AppRolesTests.cs',
+				templated: false
+			}
+		]
+	});
+}

--- a/packages/core/src/manifests/avatars.ts
+++ b/packages/core/src/manifests/avatars.ts
@@ -1,0 +1,45 @@
+import { registerManifest } from '../features/manifest.js';
+
+/** Registers the avatars feature manifest - avatar uploads with image processing. */
+export function registerAvatarsManifest(): void {
+	registerManifest({
+		featureId: 'avatars',
+		files: [
+			// Application
+			{
+				path: 'src/backend/MyProject.Application/Features/Avatar/Dtos/ProcessedImageOutput.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Application/Features/Avatar/IImageProcessingService.cs',
+				templated: false
+			},
+
+			// Infrastructure
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Avatar/Extensions/ServiceCollectionExtensions.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Avatar/Services/ImageProcessingService.cs',
+				templated: false
+			},
+
+			// WebApi
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Users/Dtos/UploadAvatar/UploadAvatarRequest.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Users/Dtos/UploadAvatar/UploadAvatarRequestValidator.cs',
+				templated: false
+			},
+
+			// Tests
+			{
+				path: 'src/backend/tests/MyProject.Component.Tests/Services/ImageProcessingServiceTests.cs',
+				templated: false
+			}
+		]
+	});
+}

--- a/packages/core/src/manifests/captcha.ts
+++ b/packages/core/src/manifests/captcha.ts
@@ -1,0 +1,32 @@
+import { registerManifest } from '../features/manifest.js';
+
+/** Registers the captcha feature manifest - Cloudflare Turnstile captcha verification. */
+export function registerCaptchaManifest(): void {
+	registerManifest({
+		featureId: 'captcha',
+		files: [
+			// Application
+			{ path: 'src/backend/MyProject.Application/Features/Captcha/ICaptchaService.cs', templated: false },
+
+			// Infrastructure
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Captcha/Extensions/ServiceCollectionExtensions.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Captcha/Options/CaptchaOptions.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Captcha/Services/TurnstileCaptchaService.cs',
+				templated: false
+			},
+
+			// Tests
+			{
+				path: 'src/backend/tests/MyProject.Component.Tests/Validation/CaptchaOptionsValidationTests.cs',
+				templated: false
+			}
+		]
+	});
+}

--- a/packages/core/src/manifests/email-verification.ts
+++ b/packages/core/src/manifests/email-verification.ts
@@ -1,0 +1,53 @@
+import { registerManifest } from '../features/manifest.js';
+
+/** Registers the email-verification feature manifest - email verification flow with token management. */
+export function registerEmailVerificationManifest(): void {
+	registerManifest({
+		featureId: 'email-verification',
+		files: [
+			// Application
+			{
+				path: 'src/backend/MyProject.Application/Features/Authentication/Dtos/VerifyEmailInput.cs',
+				templated: false
+			},
+
+			// Infrastructure
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Authentication/Models/EmailToken.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Authentication/Models/EmailTokenPurpose.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Authentication/Configurations/EmailTokenConfiguration.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Authentication/Services/EmailTokenService.cs',
+				templated: false
+			},
+
+			// WebApi
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Authentication/EmailVerificationController.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Authentication/Dtos/VerifyEmail/VerifyEmailRequest.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Authentication/Dtos/VerifyEmail/VerifyEmailRequestValidator.cs',
+				templated: false
+			},
+
+			// Tests
+			{
+				path: 'src/backend/tests/MyProject.Api.Tests/Validators/VerifyEmailRequestValidatorTests.cs',
+				templated: false
+			}
+		]
+	});
+}

--- a/packages/core/src/manifests/email.ts
+++ b/packages/core/src/manifests/email.ts
@@ -1,0 +1,139 @@
+import { registerManifest } from '../features/manifest.js';
+
+/** Registers the email feature manifest - SMTP email sending, Fluid templates, and email rendering. */
+export function registerEmailManifest(): void {
+	registerManifest({
+		featureId: 'email',
+		files: [
+			// Application
+			{ path: 'src/backend/MyProject.Application/Features/Email/EmailMessage.cs', templated: false },
+			{
+				path: 'src/backend/MyProject.Application/Features/Email/EmailTemplateNames.cs',
+				templated: false
+			},
+			{ path: 'src/backend/MyProject.Application/Features/Email/IEmailService.cs', templated: false },
+			{
+				path: 'src/backend/MyProject.Application/Features/Email/IEmailTemplateRenderer.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Application/Features/Email/ITemplatedEmailSender.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Application/Features/Email/Models/EmailTemplateModels.cs',
+				templated: false
+			},
+
+			// Infrastructure - Services
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Email/Extensions/ServiceCollectionExtensions.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Email/Options/EmailOptions.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Email/Services/FluidEmailTemplateRenderer.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Email/Services/NoOpEmailService.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Email/Services/SmtpEmailService.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Email/Services/TemplatedEmailSender.cs',
+				templated: false
+			},
+
+			// Infrastructure - Templates
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Email/Templates/_base.liquid',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Email/Templates/verify-email.liquid',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Email/Templates/verify-email.subject.liquid',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Email/Templates/verify-email.text.liquid',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Email/Templates/reset-password.liquid',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Email/Templates/reset-password.subject.liquid',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Email/Templates/reset-password.text.liquid',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Email/Templates/invitation.liquid',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Email/Templates/invitation.subject.liquid',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Email/Templates/invitation.text.liquid',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Email/Templates/admin-reset-password.liquid',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Email/Templates/admin-reset-password.subject.liquid',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Email/Templates/admin-reset-password.text.liquid',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Email/Templates/admin-disable-2fa.liquid',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Email/Templates/admin-disable-2fa.subject.liquid',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Email/Templates/admin-disable-2fa.text.liquid',
+				templated: false
+			},
+
+			// Tests
+			{
+				path: 'src/backend/tests/MyProject.Component.Tests/Services/FluidEmailTemplateRendererTests.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/tests/MyProject.Component.Tests/Services/SmtpEmailServiceTests.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/tests/MyProject.Component.Tests/Services/TemplatedEmailSenderTests.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/tests/MyProject.Component.Tests/Validation/EmailOptionsValidationTests.cs',
+				templated: false
+			}
+		]
+	});
+}

--- a/packages/core/src/manifests/file-storage.ts
+++ b/packages/core/src/manifests/file-storage.ts
@@ -1,0 +1,39 @@
+import { registerManifest } from '../features/manifest.js';
+
+/** Registers the file-storage feature manifest - S3/MinIO file storage with upload and download. */
+export function registerFileStorageManifest(): void {
+	registerManifest({
+		featureId: 'file-storage',
+		files: [
+			// Application
+			{
+				path: 'src/backend/MyProject.Application/Features/FileStorage/Dtos/FileDownloadOutput.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Application/Features/FileStorage/IFileStorageService.cs',
+				templated: false
+			},
+
+			// Infrastructure
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/FileStorage/Extensions/ServiceCollectionExtensions.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/FileStorage/Options/FileStorageOptions.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/FileStorage/Services/S3FileStorageService.cs',
+				templated: false
+			},
+
+			// Tests
+			{
+				path: 'src/backend/tests/MyProject.Component.Tests/Validation/FileStorageOptionsValidationTests.cs',
+				templated: false
+			}
+		]
+	});
+}

--- a/packages/core/src/manifests/frontend.ts
+++ b/packages/core/src/manifests/frontend.ts
@@ -1,0 +1,10 @@
+import { registerManifest } from '../features/manifest.js';
+
+/** Registers the frontend feature manifest - SvelteKit frontend. No templates yet; placeholder for future use. */
+export function registerFrontendManifest(): void {
+	registerManifest({
+		featureId: 'frontend',
+		// No frontend templates in the repo yet - will be populated when SvelteKit templates are added
+		files: []
+	});
+}

--- a/packages/core/src/manifests/index.ts
+++ b/packages/core/src/manifests/index.ts
@@ -1,7 +1,34 @@
+import { registerAdminManifest } from './admin.js';
+import { registerAspireManifest } from './aspire.js';
+import { registerAuditManifest } from './audit.js';
+import { registerAuthManifest } from './auth.js';
+import { registerAvatarsManifest } from './avatars.js';
+import { registerCaptchaManifest } from './captcha.js';
 import { registerCoreManifest } from './core.js';
+import { registerEmailManifest } from './email.js';
+import { registerEmailVerificationManifest } from './email-verification.js';
+import { registerFileStorageManifest } from './file-storage.js';
+import { registerFrontendManifest } from './frontend.js';
+import { registerJobsManifest } from './jobs.js';
+import { registerOAuthManifest } from './oauth.js';
+import { registerPasswordResetManifest } from './password-reset.js';
+import { registerTwoFactorManifest } from './two-factor.js';
 
 /** Registers all feature manifests. Call once before generating a project. */
 export function registerAllManifests(): void {
 	registerCoreManifest();
-	// Phase 3: auth, email, jobs, audit, admin, etc.
+	registerAuthManifest();
+	registerEmailManifest();
+	registerEmailVerificationManifest();
+	registerPasswordResetManifest();
+	registerTwoFactorManifest();
+	registerOAuthManifest();
+	registerCaptchaManifest();
+	registerJobsManifest();
+	registerFileStorageManifest();
+	registerAvatarsManifest();
+	registerAuditManifest();
+	registerAdminManifest();
+	registerAspireManifest();
+	registerFrontendManifest();
 }

--- a/packages/core/src/manifests/jobs.ts
+++ b/packages/core/src/manifests/jobs.ts
@@ -1,0 +1,100 @@
+import { registerManifest } from '../features/manifest.js';
+
+/** Registers the jobs feature manifest - Hangfire background job scheduling, management, and recurring jobs. */
+export function registerJobsManifest(): void {
+	registerManifest({
+		featureId: 'jobs',
+		files: [
+			// Application
+			{
+				path: 'src/backend/MyProject.Application/Features/Jobs/Dtos/JobExecutionOutput.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Application/Features/Jobs/Dtos/RecurringJobDetailOutput.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Application/Features/Jobs/Dtos/RecurringJobOutput.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Application/Features/Jobs/IJobManagementService.cs',
+				templated: false
+			},
+
+			// Infrastructure
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Jobs/Configurations/PausedJobConfiguration.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Jobs/Examples/ExampleFireAndForgetJob.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Jobs/Extensions/ApplicationBuilderExtensions.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Jobs/Extensions/ServiceCollectionExtensions.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Jobs/IRecurringJobDefinition.cs',
+				templated: false
+			},
+			{ path: 'src/backend/MyProject.Infrastructure/Features/Jobs/Models/PausedJob.cs', templated: false },
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Jobs/Options/JobSchedulingOptions.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Jobs/RecurringJobs/ExpiredEmailTokenCleanupJob.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Jobs/RecurringJobs/ExpiredRefreshTokenCleanupJob.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Jobs/RecurringJobs/ExpiredTwoFactorChallengeCleanupJob.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Jobs/Services/JobManagementService.cs',
+				templated: false
+			},
+
+			// WebApi
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Admin/JobsController.cs',
+				templated: false
+			},
+			{ path: 'src/backend/MyProject.WebApi/Features/Admin/JobsMapper.cs', templated: false },
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Admin/Dtos/Jobs/JobExecutionResponse.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Admin/Dtos/Jobs/RecurringJobDetailResponse.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Admin/Dtos/Jobs/RecurringJobResponse.cs',
+				templated: false
+			},
+			{ path: 'src/backend/MyProject.WebApi/Routing/JobIdRouteConstraint.cs', templated: false },
+
+			// Tests
+			{
+				path: 'src/backend/tests/MyProject.Api.Tests/Controllers/JobsControllerTests.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/tests/MyProject.Component.Tests/Validation/JobSchedulingOptionsValidationTests.cs',
+				templated: false
+			}
+		]
+	});
+}

--- a/packages/core/src/manifests/oauth.ts
+++ b/packages/core/src/manifests/oauth.ts
@@ -1,0 +1,259 @@
+import { registerManifest } from '../features/manifest.js';
+
+/** Registers the oauth feature manifest - external OAuth providers, admin OAuth config, and provider management. */
+export function registerOAuthManifest(): void {
+	registerManifest({
+		featureId: 'oauth',
+		files: [
+			// Application - DTOs
+			{
+				path: 'src/backend/MyProject.Application/Features/Authentication/Dtos/ExternalCallbackInput.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Application/Features/Authentication/Dtos/ExternalCallbackOutput.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Application/Features/Authentication/Dtos/ExternalChallengeInput.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Application/Features/Authentication/Dtos/ExternalChallengeOutput.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Application/Features/Authentication/Dtos/ExternalProviderInfo.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Application/Features/Authentication/Dtos/ProviderConfigOutput.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Application/Features/Authentication/Dtos/ProviderCredentialsOutput.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Application/Features/Authentication/Dtos/UpsertProviderConfigInput.cs',
+				templated: false
+			},
+
+			// Application - Interfaces
+			{
+				path: 'src/backend/MyProject.Application/Features/Authentication/IExternalAuthService.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Application/Features/Authentication/IProviderConfigService.cs',
+				templated: false
+			},
+
+			// Infrastructure - Configurations
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Authentication/Configurations/ExternalAuthStateConfiguration.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Authentication/Configurations/ExternalProviderConfigConfiguration.cs',
+				templated: false
+			},
+
+			// Infrastructure - Models
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Authentication/Models/ExternalAuthState.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Authentication/Models/ExternalProviderConfig.cs',
+				templated: false
+			},
+
+			// Infrastructure - Options
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Authentication/Options/ExternalAuthOptions.cs',
+				templated: false
+			},
+
+			// Infrastructure - Services
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Authentication/Services/ExternalAuthService.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Authentication/Services/ProviderConfigService.cs',
+				templated: false
+			},
+
+			// Infrastructure - External providers
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Authentication/Services/ExternalProviders/AppleAuthProvider.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Authentication/Services/ExternalProviders/DiscordAuthProvider.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Authentication/Services/ExternalProviders/ExternalUserInfo.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Authentication/Services/ExternalProviders/FacebookAuthProvider.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Authentication/Services/ExternalProviders/GitHubAuthProvider.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Authentication/Services/ExternalProviders/GitLabAuthProvider.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Authentication/Services/ExternalProviders/GoogleAuthProvider.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Authentication/Services/ExternalProviders/IExternalAuthProvider.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Authentication/Services/ExternalProviders/LinkedInAuthProvider.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Authentication/Services/ExternalProviders/MicrosoftAuthProvider.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Authentication/Services/ExternalProviders/ProviderCredentials.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Authentication/Services/ExternalProviders/SlackAuthProvider.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Authentication/Services/ExternalProviders/TwitchAuthProvider.cs',
+				templated: false
+			},
+
+			// WebApi - External auth controller
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Authentication/ExternalAuthController.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Authentication/Dtos/External/ExternalCallbackRequest.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Authentication/Dtos/External/ExternalCallbackRequestValidator.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Authentication/Dtos/External/ExternalCallbackResponse.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Authentication/Dtos/External/ExternalChallengeRequest.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Authentication/Dtos/External/ExternalChallengeRequestValidator.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Authentication/Dtos/External/ExternalChallengeResponse.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Authentication/Dtos/External/ExternalProviderResponse.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Authentication/Dtos/External/ExternalUnlinkRequest.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Authentication/Dtos/External/ExternalUnlinkRequestValidator.cs',
+				templated: false
+			},
+
+			// WebApi - Routing
+			{
+				path: 'src/backend/MyProject.WebApi/Routing/ProviderNameRouteConstraint.cs',
+				templated: false
+			},
+
+			// WebApi - Admin OAuth providers
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Admin/OAuthProvidersController.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Admin/OAuthProvidersMapper.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Admin/Dtos/OAuthProviders/OAuthProviderConfigResponse.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Admin/Dtos/OAuthProviders/UpdateOAuthProviderRequest.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Admin/Dtos/OAuthProviders/UpdateOAuthProviderRequestValidator.cs',
+				templated: false
+			},
+
+			// Tests
+			{
+				path: 'src/backend/tests/MyProject.Api.Tests/Controllers/ExternalAuthControllerTests.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/tests/MyProject.Api.Tests/Controllers/OAuthProvidersControllerTests.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/tests/MyProject.Api.Tests/Validators/ExternalAuthValidatorTests.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/tests/MyProject.Component.Tests/Services/ExternalAuthServiceTests.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/tests/MyProject.Component.Tests/Services/ExternalProviders/FacebookAuthProviderTests.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/tests/MyProject.Component.Tests/Services/ExternalProviders/GitLabAuthProviderTests.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/tests/MyProject.Component.Tests/Services/ExternalProviders/LinkedInAuthProviderTests.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/tests/MyProject.Component.Tests/Services/ExternalProviders/MicrosoftAuthProviderTests.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/tests/MyProject.Component.Tests/Services/ExternalProviders/SlackAuthProviderTests.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/tests/MyProject.Component.Tests/Services/ExternalProviders/TwitchAuthProviderTests.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/tests/MyProject.Component.Tests/Validation/ExternalAuthOptionsValidationTests.cs',
+				templated: false
+			}
+		]
+	});
+}

--- a/packages/core/src/manifests/password-reset.ts
+++ b/packages/core/src/manifests/password-reset.ts
@@ -1,0 +1,59 @@
+import { registerManifest } from '../features/manifest.js';
+
+/** Registers the password-reset feature manifest - forgot password and reset password flows. */
+export function registerPasswordResetManifest(): void {
+	registerManifest({
+		featureId: 'password-reset',
+		files: [
+			// Application
+			{
+				path: 'src/backend/MyProject.Application/Features/Authentication/Dtos/ResetPasswordInput.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Application/Features/Authentication/Dtos/SetPasswordInput.cs',
+				templated: false
+			},
+
+			// WebApi
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Authentication/PasswordController.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Authentication/Dtos/ForgotPassword/ForgotPasswordRequest.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Authentication/Dtos/ForgotPassword/ForgotPasswordRequestValidator.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Authentication/Dtos/ResetPassword/ResetPasswordRequest.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Authentication/Dtos/ResetPassword/ResetPasswordRequestValidator.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Authentication/Dtos/SetPassword/SetPasswordRequest.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Authentication/Dtos/SetPassword/SetPasswordRequestValidator.cs',
+				templated: false
+			},
+
+			// Tests
+			{
+				path: 'src/backend/tests/MyProject.Api.Tests/Validators/ForgotPasswordRequestValidatorTests.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/tests/MyProject.Api.Tests/Validators/ResetPasswordRequestValidatorTests.cs',
+				templated: false
+			}
+		]
+	});
+}

--- a/packages/core/src/manifests/two-factor.ts
+++ b/packages/core/src/manifests/two-factor.ts
@@ -1,0 +1,101 @@
+import { registerManifest } from '../features/manifest.js';
+
+/** Registers the 2fa feature manifest - two-factor authentication setup, verification, and recovery. */
+export function registerTwoFactorManifest(): void {
+	registerManifest({
+		featureId: '2fa',
+		files: [
+			// Application
+			{
+				path: 'src/backend/MyProject.Application/Features/Authentication/Dtos/TwoFactorSetupOutput.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Application/Features/Authentication/Dtos/TwoFactorVerifySetupOutput.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Application/Features/Authentication/ITwoFactorService.cs',
+				templated: false
+			},
+
+			// Infrastructure
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Authentication/Models/TwoFactorChallenge.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Authentication/Configurations/TwoFactorChallengeConfiguration.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.Infrastructure/Features/Authentication/Services/TwoFactorService.cs',
+				templated: false
+			},
+
+			// WebApi
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Authentication/TwoFactorController.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Authentication/Dtos/TwoFactor/TwoFactorDisableRequest.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Authentication/Dtos/TwoFactor/TwoFactorDisableRequestValidator.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Authentication/Dtos/TwoFactor/TwoFactorLoginRequest.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Authentication/Dtos/TwoFactor/TwoFactorLoginRequestValidator.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Authentication/Dtos/TwoFactor/TwoFactorRecoveryLoginRequest.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Authentication/Dtos/TwoFactor/TwoFactorRecoveryLoginRequestValidator.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Authentication/Dtos/TwoFactor/TwoFactorRegenerateCodesRequest.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Authentication/Dtos/TwoFactor/TwoFactorRegenerateCodesRequestValidator.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Authentication/Dtos/TwoFactor/TwoFactorSetupResponse.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Authentication/Dtos/TwoFactor/TwoFactorVerifySetupRequest.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Authentication/Dtos/TwoFactor/TwoFactorVerifySetupRequestValidator.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/MyProject.WebApi/Features/Authentication/Dtos/TwoFactor/TwoFactorVerifySetupResponse.cs',
+				templated: false
+			},
+
+			// Tests
+			{
+				path: 'src/backend/tests/MyProject.Component.Tests/Services/TwoFactorServiceTests.cs',
+				templated: false
+			},
+			{
+				path: 'src/backend/tests/MyProject.Api.Tests/Validators/TwoFactorValidatorTests.cs',
+				templated: false
+			}
+		]
+	});
+}


### PR DESCRIPTION
## Summary

- Create manifests for all 14 features: auth, email, email-verification, password-reset, 2fa, oauth, captcha, jobs, file-storage, avatars, audit, admin, aspire, frontend (placeholder)
- All 410 template files assigned to exactly one manifest, zero duplicates
- Full preset generates 410 files that build with 0 errors
- Unit (97), architecture (10), and component (540) tests all pass

## Test plan

- [x] `pnpm test` - all 56 TypeScript tests pass (core-only regression)
- [x] Full preset `dotnet build` - 0 errors
- [x] Full preset `dotnet test` (excluding API integration) - 647 passed, 14 skipped
- [x] Core-only preset still generates 79 files and builds clean
- [x] File coverage: 410/410 template files assigned

Closes #30 #31 #32 #33 #34 #35 #36 #37 #38 #39 #41 #42 #43